### PR TITLE
Kanban reorder + Team filter + Secure rules + Husky standardization

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,17 +3,36 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
+    // Users: a user can read their own user document and update limited fields
+    match /users/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Teams: members can read; creators (or future admins) can write
+    match /teams/{teamId} {
+      allow read: if request.auth != null && request.auth.uid in resource.data.members;
+      allow create: if request.auth != null && request.resource.data.members.size() > 0 && request.auth.uid in request.resource.data.members;
+      allow update, delete: if request.auth != null && request.auth.uid == resource.data.createdBy;
+    }
+
+    // Tasks: readable and writable by members of the task's team or creator
+    match /tasks/{taskId} {
+      function isTeamMember(teamId) {
+        return exists(/databases/$(database)/documents/teams/$(teamId)) &&
+               request.auth.uid in get(/databases/$(database)/documents/teams/$(teamId)).data.members;
+      }
+
+      allow read: if request.auth != null && isTeamMember(resource.data.teamId);
+      allow create: if request.auth != null && isTeamMember(request.resource.data.teamId);
+      allow update, delete: if request.auth != null && (
+        isTeamMember(resource.data.teamId) || request.auth.uid == resource.data.createdBy
+      );
+    }
+
+    // Deny everything else
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2025, 10, 6);
+      allow read, write: if false;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "firebase:emulators": "firebase emulators:start",
     "demo:create": "node scripts/create-demo-data.js",
     "demo:cleanup": "node scripts/cleanup-demo.js",
-    "precommit": "npm run format:check && npm run lint",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -61,14 +60,8 @@
   "lint-staged": {
     "*.{js,vue,json,css,scss,md}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "engines": {
     "node": ">=14.0.0",


### PR DESCRIPTION
Summary
- Tasks: Handle same-column reordering via draggable event.moved and persist order field. Cross-column moves compute fractional order and persist. Sort within status by order (fallback createdAt).
- Tasks view: Apply team filter from /tasks?team=<id>. Build per-status lists bound directly to draggable for stable reordering. Fix delete handler recursion.
- Firestore: Replace permissive rules with membership-aware rules for users/teams/tasks. Add composite index for tasks(teamId + createdAt).
- Husky: Standardize on v8. Add .husky/pre-commit to run lint-staged. Remove legacy husky hooks and precommit script.

Why
- Aligns implementation with README requirements (team navigation from Teams view, robust DnD). Secures Firestore beyond temporary permissive rules. Ensures pre-commit checks run reliably.

Notes
- Order field uses fractional values to minimize batch rewrites. New tasks default order = Date.now().
- Consider adding unit tests for date utils and tasks store in a follow-up PR.

How to test
- Navigate from Teams -> View Tasks; ensure only that team’s tasks show.
- Drag tasks within the same column and across columns; refresh to confirm order persists.
- Verify pre-commit hook runs lint-staged locally after npm install (husky install).
- Deploy Firestore rules and indexes via firebase deploy (requires appropriate Firebase project).